### PR TITLE
Improve flow of creation and viewing expense Time Periods & Create expenses form

### DIFF
--- a/expensetracker/core/filters.py
+++ b/expensetracker/core/filters.py
@@ -1,5 +1,6 @@
+from django.forms.fields import ChoiceField
 import django_filters
-from django_filters import DateFilter, CharFilter
+from django_filters import DateFilter, CharFilter, ModelChoiceFilter
 from django.forms import ModelForm, RadioSelect, DateInput, Select, CheckboxInput
 
 from .models import *
@@ -7,9 +8,10 @@ from .models import *
 class ExpenseTimePeriodFilter(django_filters.FilterSet):
     # Link describing how to set up filters, including the lte gte etc. styles
     # https://youtu.be/G-Rct7Na0UQ?t=809
-    startAfter = DateFilter(field_name='dateStart', lookup_expr='gte',widget=DateInput(format=('%d/%m/%Y'), attrs={'class':'form-control', 'placeholder':'Select a date', 'type':'date'}))
-    startBefore = DateFilter(field_name='dateStart', lookup_expr='lte',widget=DateInput(format=('%d/%m/%Y'), attrs={'class':'form-control', 'placeholder':'Select a date', 'type':'date'}))
-    note = CharFilter(field_name='description',lookup_expr='icontains')
+    category = ModelChoiceFilter(queryset=ExpenseCategory.objects.all(),widget=RadioSelect(attrs={'id':'categoryField','class':'categoryFilter'}))
+    # startAfter = DateFilter(field_name='dateStart', lookup_expr='gte',widget=DateInput(format=('%d/%m/%Y'), attrs={'class':'form-control', 'placeholder':'Select a date', 'type':'date'}))
+    # startBefore = DateFilter(field_name='dateStart', lookup_expr='lte',widget=DateInput(format=('%d/%m/%Y'), attrs={'class':'form-control', 'placeholder':'Select a date', 'type':'date'}))
+    # note = CharFilter(field_name='description',lookup_expr='icontains')
     class Meta:
         model = ExpenseTimePeriod
         fields = ['category']

--- a/expensetracker/core/forms.py
+++ b/expensetracker/core/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, RadioSelect, DateInput, Select, modelformset_factory
+from django.forms import ModelForm, RadioSelect, DateInput, Select, inlineformset_factory
 from .models import ExpenseCategory, ExpenseTimePeriod, Expense
 
 class CategoryForm(ModelForm):
@@ -20,4 +20,4 @@ class ExpenseForm(ModelForm):
         fields = ["description", "cost", "expenseTimePeriod"]
         widgets = {"category": Select()}
 
-CreateExpenseSet = modelformset_factory(Expense, fields=('description', 'cost', 'expenseTimePeriod'), extra=1)
+CreateExpenseSet = inlineformset_factory(ExpenseTimePeriod, Expense, fields=('description', 'cost','expenseTimePeriod'), extra=1)

--- a/expensetracker/core/forms.py
+++ b/expensetracker/core/forms.py
@@ -20,4 +20,4 @@ class ExpenseForm(ModelForm):
         fields = ["description", "cost", "expenseTimePeriod"]
         widgets = {"category": Select()}
 
-CreateExpenseSet = inlineformset_factory(ExpenseTimePeriod, Expense, fields=('description', 'cost','expenseTimePeriod'), extra=0)
+CreateExpenseSet = inlineformset_factory(ExpenseTimePeriod, Expense, fields=('description', 'cost','expenseTimePeriod'), extra=1)

--- a/expensetracker/core/forms.py
+++ b/expensetracker/core/forms.py
@@ -20,4 +20,4 @@ class ExpenseForm(ModelForm):
         fields = ["description", "cost", "expenseTimePeriod"]
         widgets = {"category": Select()}
 
-CreateExpenseSet = inlineformset_factory(ExpenseTimePeriod, Expense, fields=('description', 'cost','expenseTimePeriod'), extra=1)
+CreateExpenseSet = inlineformset_factory(ExpenseTimePeriod, Expense, fields=('description', 'cost','expenseTimePeriod'), extra=0)

--- a/expensetracker/core/static/app/createExpenses.js
+++ b/expensetracker/core/static/app/createExpenses.js
@@ -1,7 +1,7 @@
 let expenseFormset = document.querySelectorAll(".expense-formset")
 let container = document.querySelector("#form-container")
 let addButton = document.querySelector("#add-form")
-let totalForms = document.querySelector("#id_form-TOTAL_FORMS")
+let totalForms = document.querySelector("#id_expense_set-TOTAL_FORMS")
 
 // Functionality for adding extra entries into the formset
 let formNum = expenseFormset.length - 1 // Get the num of the last form on the page
@@ -13,10 +13,12 @@ function addForm(e) {
 
     let newForm = expenseFormset[0].cloneNode(true)  // Clone the last form
     let formRegex = RegExp(`form-(\\d){1}-`,'g') // Regex to find all instances of the form number
-
+    
     formNum++ // Increment the form number
     newForm.innerHTML = newForm.innerHTML.replace(formRegex, `form-${formNum}-`)
     container.insertBefore(newForm, addButton)
-
+    
     totalForms.setAttribute('value',`${formNum+1}`) // Increment the total number of forms in the hidden input 
+    const newInputs = newForm.querySelectorAll('input')
+    newInputs.forEach(input => input.value = '')
 }

--- a/expensetracker/core/static/app/createExpenses.js
+++ b/expensetracker/core/static/app/createExpenses.js
@@ -12,13 +12,13 @@ function addForm(e) {
     e.preventDefault()
 
     let newForm = expenseFormset[0].cloneNode(true)  // Clone the last form
-    let formRegex = RegExp(`form-(\\d){1}-`,'g') // Regex to find all instances of the form number
+    let formRegex = RegExp(`expense_set-(\\d){1}-`,'g') // Regex to find all instances of the form number
     
     formNum++ // Increment the form number
-    newForm.innerHTML = newForm.innerHTML.replace(formRegex, `form-${formNum}-`)
+    newForm.innerHTML = newForm.innerHTML.replace(formRegex, `expense_set-${formNum}-`)
     container.insertBefore(newForm, addButton)
     
     totalForms.setAttribute('value',`${formNum+1}`) // Increment the total number of forms in the hidden input 
-    const newInputs = newForm.querySelectorAll('input')
+    let newInputs = newForm.querySelectorAll("input:not([type=hidden])")
     newInputs.forEach(input => input.value = '')
 }

--- a/expensetracker/core/static/app/expenseTimePeriod.js
+++ b/expensetracker/core/static/app/expenseTimePeriod.js
@@ -76,3 +76,24 @@ const updateDeletedUI = (id) => {
     deletedCard = document.getElementById(`${id}-wrapper`)
     deletedCard.parentNode.removeChild(deletedCard);
 }
+
+
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+const selectElement = document.querySelector('#categoryField');
+
+selectElement.addEventListener('change', (event) => {
+    console.log(event.target.value)
+    const categorySelectedDynamic = document.querySelector(`input.categoryRadioSelect[value='${event.target.value}']`)
+    categorySelectedDynamic.checked = true;
+    // const result = document.querySelector('.result');
+    // result.textContent = `You like ${event.target.value}`;
+  });
+
+const queryString = window.location.search
+if (queryString != "") {
+const urlParams = new URLSearchParams(queryString);
+const category = urlParams.get('category')
+const categorySelected = document.querySelector(`input.categoryRadioSelect[value='${category}']`)
+categorySelected.checked = true;
+console.log(categorySelected)
+}

--- a/expensetracker/core/static/app/style.css
+++ b/expensetracker/core/static/app/style.css
@@ -99,6 +99,10 @@ input[type="radio"] {
 
 /* Outer container for categories checkboxes */
 ul.categoryRadioSelect {
+  display: none;
+}
+
+ul.categoryFilter {
   margin: 10px 0;
   border-radius: 20px;
   box-shadow: 0 0 3px black;
@@ -107,7 +111,7 @@ ul.categoryRadioSelect {
 
 /* Instruction to create a clickable area https://ishadeed.com/article/clickable-area/
 2nd inner container for categories checkboxes */
-ul.categoryRadioSelect label {
+ul.categoryFilter label {
   display: block;
   padding: 8px 0;
   cursor: pointer;
@@ -118,7 +122,7 @@ ul.categoryRadioSelect label {
   text-align: center;
 }
 
-input.categoryRadioSelect {
+input.categoryFilter {
   height: 100%;
   width: 100%;
   z-index: -1;
@@ -131,7 +135,7 @@ input.categoryRadioSelect {
 
 }
 
-input.categoryRadioSelect:checked {
+input.categoryFilter:checked {
   transition: background-color 0.3s;
   background: #006b56;
 }

--- a/expensetracker/core/static/app/style.css
+++ b/expensetracker/core/static/app/style.css
@@ -363,3 +363,15 @@ Right border set green or red in js for income vs expense */
     width: 300px;
   }
 }
+
+
+.expense-formset p {
+  display: inline-block;
+}
+
+.expense-formset label {
+  display: inline-block;
+}
+.expense-formset input {
+  display: inline-block;
+}

--- a/expensetracker/core/urls.py
+++ b/expensetracker/core/urls.py
@@ -14,7 +14,6 @@ urlpatterns = [
     path("timeperiods/", views.time_period, name="timeperiods"),
     path("timeperiods/<str:pk>", views.time_period, name="timeperiodsSelected"),
     # https://www.pluralsight.com/guides/work-with-ajax-django
-    path("createExpenses/", views.createExpenses, name="createExpenses"),
-    path("createExpenses/<str:pk>", views.createExpenses, name="createExpensesSelected"),
+    path("createExpenses/<str:pk>", views.createExpenses, name="createExpenses"),
     path('api/',include(router.urls)),
 ]

--- a/expensetracker/core/views.py
+++ b/expensetracker/core/views.py
@@ -52,7 +52,7 @@ def time_period (request, pk=None):
         timePeriodPerCategory = ExpenseTimePeriod.objects.all()
         expenseCategory = None
     else:
-        timePeriodPerCategory = ExpenseTimePeriod.objects.filter(category__pk=pk)
+        timePeriodPerCategory = ExpenseTimePeriod.objects.all()
         expenseCategory = ExpenseCategory.objects.get(id=pk)
     if request.method == "POST":
         # Create a form instance and populate with data from the request
@@ -132,7 +132,7 @@ def createExpenses(request, pk=None):
             if formset.is_valid():
                 formset.save()
                 messages.success(request, "Expense submitted successfully.")
-                return HttpResponseRedirect(reverse('core:createExpenses',kwargs={'pk': pk}))
+                return HttpResponseRedirect(reverse('core:timeperiods'))
             else:
                 messages.error(request, "Invalid Form Submission") 
     else:

--- a/expensetracker/core/views.py
+++ b/expensetracker/core/views.py
@@ -135,21 +135,22 @@ def createExpenses(request, pk=None):
                 messages.error(request, "Invalid Form Submission")
         if "formset" in request.POST:
             formset = CreateExpenseSet(data=request.POST, instance=expenseTimePeriod)
-
             form = ExpenseForm(initial={'expenseTimePeriod':expenseTimePeriod})
             #Check if submitted forms are valid
             if formset.is_valid():
                 formset.save()
+                messages.success(request, "Expense submitted successfully.")
                 return HttpResponseRedirect(reverse('core:createExpensesSelected',kwargs={'pk': pk}))
-            
+            else:
+                messages.error(request, "Invalid Form Submission") 
     else:
-    # Use id to fill in the initial value of the foreign key
-    # https://youtu.be/MRWFg30FmZQ?t=128
+        # Use id to fill in the initial value of the foreign key
+        # https://youtu.be/MRWFg30FmZQ?t=128
         form = ExpenseForm(initial={'expenseTimePeriod':expenseTimePeriod})
+        # Use of formsets
+        # https://www.brennantymrak.com/articles/django-dynamic-formsets-javascript.html
+        formset = CreateExpenseSet(instance=expenseTimePeriod)
 
-    # Use of formsets
-    # https://www.brennantymrak.com/articles/django-dynamic-formsets-javascript.html
-    formset = CreateExpenseSet(instance=expenseTimePeriod)
     context = {
         "form": form,
         "expenses": expensesPerCategory,

--- a/expensetracker/core/views.py
+++ b/expensetracker/core/views.py
@@ -134,12 +134,14 @@ def createExpenses(request, pk=None):
             else:
                 messages.error(request, "Invalid Form Submission")
         if "formset" in request.POST:
-            formset = CreateExpenseSet(data=request.POST)
+            formset = CreateExpenseSet(data=request.POST, instance=expenseTimePeriod)
 
+            form = ExpenseForm(initial={'expenseTimePeriod':expenseTimePeriod})
             #Check if submitted forms are valid
             if formset.is_valid():
                 formset.save()
-                return HttpResponseRedirect("/createExpenses/")
+                return HttpResponseRedirect(reverse('core:createExpensesSelected',kwargs={'pk': pk}))
+            
     else:
     # Use id to fill in the initial value of the foreign key
     # https://youtu.be/MRWFg30FmZQ?t=128
@@ -147,7 +149,7 @@ def createExpenses(request, pk=None):
 
     # Use of formsets
     # https://www.brennantymrak.com/articles/django-dynamic-formsets-javascript.html
-    formset = CreateExpenseSet(queryset=Expense.objects.none())
+    formset = CreateExpenseSet(instance=expenseTimePeriod)
     context = {
         "form": form,
         "expenses": expensesPerCategory,

--- a/expensetracker/core/views.py
+++ b/expensetracker/core/views.py
@@ -70,7 +70,7 @@ def time_period (request, pk=None):
             # https://docs.djangoproject.com/en/3.2/ref/urlresolvers/
             # >>> reverse('admin:app_list', kwargs={'app_label': 'auth'})
             # '/admin/auth/'
-            return HttpResponseRedirect(reverse('core:createExpensesSelected',kwargs={'pk': instance.id}))
+            return HttpResponseRedirect(reverse('core:createExpenses',kwargs={'pk': instance.id}))
         else:
             messages.error(request, "Invalid form submission.")
     else:
@@ -125,14 +125,6 @@ def createExpenses(request, pk=None):
         expenseTimePeriod = ExpenseTimePeriod.objects.get(id=pk)
 
     if request.method == "POST":
-        if "form" in request.POST:
-            form = ExpenseForm(request.POST)
-            if form.is_valid():
-                form.save()
-                messages.success(request, "Expense submitted successfully.")
-                return HttpResponseRedirect("/createExpenses/")
-            else:
-                messages.error(request, "Invalid Form Submission")
         if "formset" in request.POST:
             formset = CreateExpenseSet(data=request.POST, instance=expenseTimePeriod)
             form = ExpenseForm(initial={'expenseTimePeriod':expenseTimePeriod})
@@ -140,7 +132,7 @@ def createExpenses(request, pk=None):
             if formset.is_valid():
                 formset.save()
                 messages.success(request, "Expense submitted successfully.")
-                return HttpResponseRedirect(reverse('core:createExpensesSelected',kwargs={'pk': pk}))
+                return HttpResponseRedirect(reverse('core:createExpenses',kwargs={'pk': pk}))
             else:
                 messages.error(request, "Invalid Form Submission") 
     else:
@@ -152,7 +144,6 @@ def createExpenses(request, pk=None):
         formset = CreateExpenseSet(instance=expenseTimePeriod)
 
     context = {
-        "form": form,
         "expenses": expensesPerCategory,
         "expenseTimePeriod": expenseTimePeriod,
         "formset":formset,

--- a/templates/core/app.html
+++ b/templates/core/app.html
@@ -25,7 +25,7 @@
       <div class="history-card-container" id="history-card-container">
         {% for card in category %}
           <div class="history-card-wrapper" id="{{card.id}}-wrapper">
-            <a href="{% url 'core:timeperiodsSelected' card.id %}">
+            <a href="{% url 'core:timeperiodsSelected' card.id %}?category={{card.id}}">
               <div class="history-card">
                 <span>
                   <strong>{{card.name}}</strong><br>

--- a/templates/core/createExpenses.html
+++ b/templates/core/createExpenses.html
@@ -23,29 +23,22 @@
     <form id='form-container' method="POST"> 
       {% csrf_token %}
       {{formset.management_form}}
+        {{formset.non_form_errors}}
       {% for form in formset %}
       <div class="expense-formset">
         {{form.as_p}}
       </div>
+        {{ form.non_field_errors }}
       {% endfor %}
       <button id="add-form" type="button">Add Another Expense</button>
+      {% for dict in formset.errors %}
+          {% for error in dict.values %}
+              {{ error.values }}
+          {% endfor %}
+      {% endfor %}
       <button type="submit" name="formset">Submit Changes</button>
     </form>
   </section>
-    <section class="history-section">
-      <h1>{{expenseTimePeriod.description}}</h1>
-      <div class="history-card-container" id="history-card-container">
-        {% for card in expenses %}
-        <div class="history-card">
-          <span>
-          <strong>{{card.description}}</strong><br>
-          <i>[{{card.expenseTimePeriod.description}}]</i>
-        </span>
-          <p>${{card.cost}}</p>
-        </div>
-        {% endfor %}
-      </div>
-    </section>
   </main>
 {% else %}
 <p>You are not logged in</p>

--- a/templates/core/createExpenses.html
+++ b/templates/core/createExpenses.html
@@ -1,20 +1,7 @@
 {% extends "base.html" %} {% load static %} {% block content %}
-{% include "core/includes/tabs.html" with active_tab='createExpenses' %}
+{% include "core/includes/tabs.html" with active_tab='timeperiods' %}
 {% if user.is_authenticated %}
   <div class="sidebar">
-    <h2>Add new Expense</h2>
-    <form action="/createExpenses/" method="post">
-      {% csrf_token %} {{ form.non_field_errors }}
-      <div class="fieldWrapper">
-        <label for="id_description">Description</label>
-        {{form.description}}
-        <label for="id_cost">Cost</label>
-        {{form.cost }} {{ form.expenseTimePeriod.errors }}
-        {{form.expenseTimePeriod.label_tag }} {{ form.expenseTimePeriod}}
-        <span class="helptext">{{ form.expenseTimePeriod.help_text }}</span>
-      </div>
-      <input type="submit" name="form" value="Submit" />
-    </form>
     <p>{% include 'core/includes/messages.html' %}</p>
   </div>
   <main>

--- a/templates/core/createExpenses.html
+++ b/templates/core/createExpenses.html
@@ -29,7 +29,7 @@
       </div>
       {% endfor %}
       <button id="add-form" type="button">Add Another Expense</button>
-      <button type="submit" name="formset">Create Expenses</button>
+      <button type="submit" name="formset">Submit Changes</button>
     </form>
   </section>
     <section class="history-section">

--- a/templates/core/createExpenses.html
+++ b/templates/core/createExpenses.html
@@ -7,7 +7,8 @@
   <main>
   <section class="formset">
     <h1>Add new Expenses</h1>
-    <form id='form-container' method="POST"> 
+    <h2>{{expenseTimePeriod}}</h2>
+    <form id='form-container' method="POST">
       {% csrf_token %}
       {{formset.management_form}}
         {{formset.non_form_errors}}
@@ -24,6 +25,7 @@
           {% endfor %}
       {% endfor %}
       <button type="submit" name="formset">Submit Changes</button>
+      <a href="/timeperiods/">Go Back Without Saving</a>
     </form>
   </section>
   </main>

--- a/templates/core/includes/tabs.html
+++ b/templates/core/includes/tabs.html
@@ -4,7 +4,6 @@ https://djangosnippets.org/snippets/2421/ -->
     <a class="{% if active_tab == 'index' %} active{% endif %}" href="{%url 'core:index' %}">Home</a>
     <a class="{% if active_tab == 'app' %} active{% endif %}" href="{%url 'core:app' %}">App</a>
     <a class="{% if active_tab == 'timeperiods' %} active{% endif %}" href="{%url 'core:timeperiods' %}">Expense Periods</a>
-    <a class="{% if active_tab == 'createExpenses' %} active{% endif %}" href="{%url 'core:createExpenses' %}">Create Expense</a>
     {% if not user.is_authenticated %}
     <a class="{% if active_tab == 'login' %} active{% endif %}" href="{% url 'account_login' %}">Log In</a>
     <a class="{% if active_tab == 'signup' %} active{% endif %}" href="{% url 'account_signup' %}">Sign Up</a>

--- a/templates/core/timePeriod.html
+++ b/templates/core/timePeriod.html
@@ -2,8 +2,21 @@
 {% include "core/includes/tabs.html" with active_tab='timeperiods' %}
 {% load myfilters %} {% if user.is_authenticated %}
   <div class="sidebar">
-  <h2>Add new Expense Period</h2>
-    <form id="ExpensePeriodForm" method="post">
+  <h2>Filter By Category</h2>
+        <section class="expensePeriodFilterForm">
+      <form method="GET">
+        {{myFilter.form}}
+      <button type="submit">Search</button>
+      </form>
+    </section>
+    <p>{% include 'core/includes/messages.html' %}</p>
+  </div>
+  <main>
+    <section class="history-section">
+      <h2>ADD EXPENSE PERIOD</h2>
+      <div class="addExpensePeriod">
+        <p>Add New</p>
+        <form id="ExpensePeriodForm" method="post">
       {% csrf_token %} {{ form.non_field_errors }}
       <div class="fieldWrapper">
         <label for="id_description">Description</label>
@@ -11,26 +24,13 @@
         <label for="id_dateStart">Start Date</label>
         {{form.dateStart }}
         <label for="id_dateEnd">End Date:</label>
-        {{form.dateEnd|addclass:"text__input" }} {{ form.category.errors }}
+        {{form.dateEnd|addclass:"text__input" }} 
+        {{ form.category.errors }}
         {{form.category.label_tag }} {{ form.category|addclass:'categoryRadioSelect' }}
         <span class="helptext">{{ form.category.help_text }}</span>
       </div>
       <input type="submit" value="Submit" />
     </form>
-    <p>{% include 'core/includes/messages.html' %}</p>
-  </div>
-  <main>
-    <section class="expensePeriodFilterForm">
-    <h1>{{expenseCategory.name}}</h1>
-    <form method="GET">
-      {{myFilter.form}}
-      <button type="submit">Search</button>
-      </form>
-    </section>
-    <section class="history-section">
-      <h2>HISTORY</h2>
-      <div class="addExpensePeriod">
-        <p>Add New</p>
       </div>
       <div class="history-card-container" id="history-card-container">
         {% for card in expenses %}

--- a/templates/core/timePeriod.html
+++ b/templates/core/timePeriod.html
@@ -29,10 +29,13 @@
     </section>
     <section class="history-section">
       <h2>HISTORY</h2>
+      <div class="addExpensePeriod">
+        <p>Add New</p>
+      </div>
       <div class="history-card-container" id="history-card-container">
         {% for card in expenses %}
         <div class="history-card-wrapper" id="{{card.id}}-wrapper">
-        <a href="{% url 'core:createExpensesSelected' card.id %}">
+        <a href="{% url 'core:createExpenses' card.id %}">
         <div class="history-card">
           <span>
           <strong>{{card.description}}</strong><br>


### PR DESCRIPTION
Re-arrange app.

The Expense Period page filtering has moved to the sidebar, and simplified to only show the radio buttons.
The form has moved to the main page, and in future will be hidden until someone clicks to Add New.
The below represents where I'm trying to get to:
![image](https://user-images.githubusercontent.com/58811856/129468778-8ffac589-3aff-4b22-8f34-d6f1acfb562d.png)

The Create Expense Page now has been corrected so now it works as intended, allows you to create additional entries, and doesn't require you to nominate an Expense Time Period each time.

Styling still needs to be added everywhere.